### PR TITLE
user guide: Fix typo from Hydrogen to Helium

### DIFF
--- a/user_guide/docs/index.md
+++ b/user_guide/docs/index.md
@@ -1,6 +1,6 @@
 # Helium User Guide
 
-[Hydrogen](https://winterbloom.com/shop/helium) is a precision, three channel, 1-to-3 buffered multiple and a 3-to-1 precision adder.
+[Helium](https://winterbloom.com/shop/helium) is a precision, three channel, 1-to-3 buffered multiple and a 3-to-1 precision adder.
 
 [TOC]
 


### PR DESCRIPTION
Fixes a typo in the link to the helium's product page. Changes the text from 'Hydrogen' to 'Helium'.